### PR TITLE
fix for https://github.com/mooz/keysnail/issues/37

### DIFF
--- a/K2Emacs.ks.js
+++ b/K2Emacs.ks.js
@@ -157,7 +157,7 @@ var ucjs_ExternalEditor = {
       if(!html.hasAttribute("__ucjs_editor_")) return;
     }catch(e){}
     
-    var textareas, filename, timestamp, encode, file, inst, sstream, utf, textBoxText
+    var textareas, filename, timestamp, encode, file, istr, sstream, utf, textBoxText;
     //すべてのtextareaとinputに関して, テンポラリファイルがあればその中身を書き戻す
     textareas = GetAllTextAreas(target);
     if (textareas.length<=0) return;
@@ -272,7 +272,7 @@ var ucjs_ExternalEditor = {
 
     // 外部エディタをランチ
     if(this.editfile(file.path, target) == false) return;
-    var html = target.ownerDocument.getElementsByTagName("html")[0];
+    var html = getBrowser().contentDocument.getElementsByTagName("html")[0];
     try{
       html.setAttribute("__ucjs_editor_",true);
     }catch(e){return;}


### PR DESCRIPTION
fix for https://github.com/mooz/keysnail/issues/37, label to html was not working

前にコミットされた修正では、iframe をつかっている時に、子の html タグに _ucjs_editor ラベルをつけていたため、入れ子になっているとき checkfocus_window が正常にはたらいていませんでした。
常に最上位の html タグにラベルをつけることで、修正しました。
