### PR TITLE
Fix that gmail edit box is not picked up

### DIFF
--- a/K2Emacs.ks.js
+++ b/K2Emacs.ks.js
@@ -420,8 +420,8 @@ var ucjs_ExternalEditor = {
   }
 };
 
-function editext() {
-    ucjs_ExternalEditor.runapp();
+function editext(ev) {
+    ucjs_ExternalEditor.runapp(ev);
     ucjs_ExternalEditor.init();
     window.addEventListener("unload", function(){ ucjs_ExternalEditor.uninit(); }, false);
 }


### PR DESCRIPTION
I think this patch does not affect other sites.
# How to reproduce this bug
- open gmail
- click [compose mail] button
- write something
- call `ext.exec("edit_text", arg, ev);`
- the editor does not have any text
